### PR TITLE
fix: prevent double API call on Enter and remove URL param usage (#14)

### DIFF
--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -8,7 +8,7 @@ const login = async (username: string, password: string): Promise<any> => {
     url: "login",
     method: "post",
     baseURL,
-    params: {
+    data: {
       username,
       password
     },

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -27,7 +27,7 @@
               <ion-card-header>
                 <ion-item lines="none">
                   <ion-thumbnail slot="start">
-                    <img alt="Silhouette of mountains" src="https://ionicframework.com/docs/img/demos/thumbnail.svg" />
+                    <img alt="Silhouette of mountains" src="../assets/images/defaultImage.png" />
                   </ion-thumbnail>
                   <ion-card-title>{{ translate("NetSuite Credentials") }}</ion-card-title>
                 </ion-item>
@@ -58,8 +58,8 @@
                     <ion-button class="ion-text-center" v-else-if="credentials.verified === 'N'" color="warning" fill="outline" size="small" @click="verifyNetsuiteCredential(credentials.systemMessageRemoteId)">
                       {{ translate("Verify")}}
                     </ion-button>
-                    <ion-button class="ion-text-center" size="default" fill="clear" @click="deleteNetsuiteCredential(credentials)">
-                      <ion-icon slot="icon-only" :icon="trashOutline" color="medium" ></ion-icon>
+                    <ion-button size="default" fill="clear" color="medium" @click="deleteNetsuiteCredential(credentials)">
+                      <ion-icon slot="icon-only" :icon="trashOutline"></ion-icon>
                     </ion-button>
                   </div>
                 </ion-item>
@@ -71,7 +71,7 @@
               <ion-card-header>
                 <ion-item lines="none">
                   <ion-thumbnail slot="start">
-                    <img alt="Silhouette of mountains" src="https://ionicframework.com/docs/img/demos/thumbnail.svg" />
+                    <img alt="Silhouette of mountains" src="../assets/images/defaultImage.png" />
                   </ion-thumbnail>
                   <ion-card-title>{{ translate("Loop Credentials") }}</ion-card-title>
                 </ion-item>
@@ -99,8 +99,8 @@
                     <ion-button class="ion-text-center" v-else-if="loopCredentials.verified === 'N'" :disabled="loopWebhookVerified.webhookSubscriptionMap[loopCredentials.systemMessageRemoteId] == 'Y' ? false : true" color="warning" fill="outline" size="small" @click="verifyloopCredential(loopCredentials)">
                       {{ translate("Subscribe") }}
                     </ion-button>
-                    <ion-button class="ion-text-center" fill="clear" size="default" @click="deleteLoopCredential(loopCredentials)">
-                      <ion-icon slot="icon-only" :icon="trashOutline" color="medium" ></ion-icon>
+                    <ion-button fill="clear" size="default" color="medium" @click="deleteLoopCredential(loopCredentials)">
+                      <ion-icon slot="icon-only" :icon="trashOutline" ></ion-icon>
                     </ion-button>
                   </div>
                 </ion-item>
@@ -152,8 +152,8 @@
                     <ion-button class="ion-text-center" v-else-if="mapping.synced == 'N'" color="warning" fill="outline" size="small" @click="syncNetsuiteMapping(mapping.integrationMappingId)" >
                       {{ translate("Sync") }}
                     </ion-button>
-                    <ion-button class="ion-text-center" fill="clear" size="default" @click="deleteIntegrationTypeMappings(mapping)">
-                      <ion-icon slot="icon-only" :icon="trashOutline" color="medium"></ion-icon>
+                    <ion-button fill="clear" size="default" color="medium" @click="deleteIntegrationTypeMappings(mapping)">
+                      <ion-icon slot="icon-only" :icon="trashOutline"></ion-icon>
                     </ion-button>
                   </div>
                 </ion-item>

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -3,11 +3,8 @@
     <ion-content>
       <div class="flex-container">
         <ion-card>
-          <form class="form-card" @keyup.enter="login(form)" @submit.prevent="login(form)">
+          <form class="form-card" @keyup.enter.stop @submit.prevent="login(form)">
             <Logo />
-            <ion-item lines="full" v-if="!baseURL">
-              <ion-input label-placement="fixed" :label="(translate('OMS'))" v-model="instanceUrl" type="text" required />
-            </ion-item>
             <ion-item lines="full">
               <ion-input label-placement="fixed" :label="(translate('Username'))" v-model="username" type="text" required />
             </ion-item>
@@ -49,8 +46,6 @@ const store = useStore();
 const username = ref("");
 const password = ref("");
 const instanceUrl = ref("");
-
-const baseURL = process.env.VUE_APP_BASE_URL;
 
 const currentInstanceUrl = computed(() => store.getters["user/getInstanceUrl"]);
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#14 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
This PR refactors the login flow to improve both security and behavior consistency.
Key updates include:

Moved credentials (username & password) from URL parameters to the request payload for better security.

Removed base URL dependency, now API calls use environment/config variables instead.

Fixed double API call issue triggered when pressing the Enter key on the login form — now only a single request is made.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/loop-netsuite#contribution-guideline)